### PR TITLE
fix: Allow tracking operations without resources [DEV-5109]

### DIFF
--- a/src/database/entities/payment.entity.ts
+++ b/src/database/entities/payment.entity.ts
@@ -43,9 +43,9 @@ export class PaymentEntity {
 	@JoinColumn({ name: 'customerId' })
 	customer!: CustomerEntity;
 
-	@ManyToOne(() => ResourceEntity, (resource) => resource.resourceId, { nullable: false, onDelete: 'CASCADE' })
+	@ManyToOne(() => ResourceEntity, (resource) => resource.resourceId, { nullable: true, onDelete: 'CASCADE' })
 	@JoinColumn({ name: 'resourceId' })
-	resource!: ResourceEntity;
+	resource!: ResourceEntity | null;
 
 	@ManyToOne(() => OperationEntity, (operation) => operation.operationId, { nullable: false, onDelete: 'CASCADE' })
 	@JoinColumn({ name: 'operationId' })
@@ -77,7 +77,7 @@ export class PaymentEntity {
 		amount: CoinEntity,
 		successful: boolean,
 		namespace: CheqdNetwork,
-		resource: ResourceEntity,
+		resource: ResourceEntity | null,
 		fromAccount: PaymentAccountEntity,
 		toAccount: string,
 		timestamp: Date

--- a/src/database/migrations/1750427001486-studio-migrations.ts
+++ b/src/database/migrations/1750427001486-studio-migrations.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class StudioMigrations1750427001486 implements MigrationInterface {
+    name = 'StudioMigrations1750427001486'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "subscription" DROP CONSTRAINT "FK_4fb9a7c3c5b5fecf58989794dcc"`);
+        await queryRunner.query(`ALTER TABLE "role" ALTER COLUMN "logToRoleIds" SET DEFAULT '{}'`);
+        await queryRunner.query(`ALTER TABLE "payment" ALTER COLUMN "resourceId" DROP NOT NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "payment" ALTER COLUMN "resourceId" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "role" ALTER COLUMN "logToRoleIds" SET DEFAULT ARRAY[]`);
+        await queryRunner.query(`ALTER TABLE "subscription" ADD CONSTRAINT "FK_4fb9a7c3c5b5fecf58989794dcc" FOREIGN KEY ("customerId") REFERENCES "customer"("customerId") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+}

--- a/src/database/types/types.ts
+++ b/src/database/types/types.ts
@@ -43,6 +43,7 @@ import { AlterCustomerTableUpdateEmail1695740346006 } from '../migrations/archiv
 import { IndexPaymentAccountTable1746513196390 } from '../migrations/archive/IndexPaymentAccountTable.js';
 import { InsertFingerprintAPIKeyTable1746780465032 } from '../migrations/archive/InsertFingerprintApiKeyTable.js';
 import { Cleanup1748331341024 } from '../migrations/custom/1748331341024-Cleanup.js';
+import { StudioMigrations1750427001486 } from '../migrations/1750427001486-studio-migrations.js';
 
 dotenv.config();
 
@@ -128,6 +129,7 @@ export class Postgres implements AbstractDatabase {
 				InsertFingerprintAPIKeyTable1746780465032,
 				// Add custom migrations
 				Cleanup1748331341024,
+				StudioMigrations1750427001486,
 			],
 			entities: [
 				...Entities,

--- a/src/services/api/payment.ts
+++ b/src/services/api/payment.ts
@@ -28,7 +28,7 @@ export class PaymentService {
 		amount: CoinEntity,
 		successful: boolean,
 		namespace: CheqdNetwork,
-		resource: ResourceEntity,
+		resource: ResourceEntity | null,
 		fromAccount: PaymentAccountEntity,
 		toAccount: string,
 		timestamp: Date
@@ -59,7 +59,7 @@ export class PaymentService {
 		amount: CoinEntity,
 		successful: boolean,
 		namespace: CheqdNetwork,
-		resource: ResourceEntity,
+		resource: ResourceEntity | null,
 		fromAccount: PaymentAccountEntity,
 		toAccount: string,
 		timestamp: Date

--- a/src/services/track/operation-subscriber.ts
+++ b/src/services/track/operation-subscriber.ts
@@ -38,12 +38,8 @@ export class DBOperationSubscriber extends BaseOperationObserver implements IObs
 		operationEntity: OperationEntity
 	): Promise<ITrackResult> {
 		const resource = await operationWithPayment.getResourceEntity();
-		if (!resource) {
-			return {
-				operation: operationWithPayment,
-				error: `Resource for operation ${operationWithPayment.name} not found. Customer: ${operationWithPayment.customer.customerId}`,
-			} satisfies ITrackResult;
-		}
+		// For some operations, there might not be an associated resource
+		// This is normal and should not be treated as an error
 
 		for (const feePayment of operationWithPayment.feePaymentOptions) {
 			// Create Fee Coin

--- a/src/types/track.ts
+++ b/src/types/track.ts
@@ -6,6 +6,7 @@ import type { LogLevelDesc } from 'loglevel';
 import type { ResourceEntity } from '../database/entities/resource.entity.js';
 import { ResourceService } from '../services/api/resource.js';
 import type { Coin } from '@cosmjs/amino';
+import { isResourceTrack } from '../services/track/helpers.js';
 
 export type TrackData =
 	| IResourceTrack
@@ -115,10 +116,10 @@ export class TrackOperationWithPayment implements ITrackOperation {
 	}
 
 	async getResourceEntity(): Promise<ResourceEntity | null> {
-		if (this.data && (this.data as IResourceTrack).resource) {
-			return await ResourceService.instance.get((this.data as IResourceTrack).resource.resourceId);
+		if (this.data && isResourceTrack(this.data) && this.data.resource) {
+			return await ResourceService.instance.get(this.data.resource.resourceId);
 		}
-		if (this.feePaymentOptions && this.feePaymentOptions[0].resourceId) {
+		if (this.feePaymentOptions && this.feePaymentOptions[0]?.resourceId) {
 			return await ResourceService.instance.get(this.feePaymentOptions[0].resourceId);
 		}
 		return null;

--- a/tests/e2e/sequential/did/create-positive.release.spec.ts
+++ b/tests/e2e/sequential/did/create-positive.release.spec.ts
@@ -8,6 +8,14 @@ import { CheqdNetwork, MethodSpecificIdAlgo, VerificationMethods, createVerifica
 
 test.use({ storageState: 'playwright/.auth/user.json' });
 
+// Helper function to handle StringOrStringArray format from DID resolver
+function getServiceEndpointValue(serviceEndpoint: string | string[]): string {
+	if (Array.isArray(serviceEndpoint)) {
+		return serviceEndpoint[0];
+	}
+	return serviceEndpoint;
+}
+
 test('[Positive] It can create DID with mandatory properties (Form based + Indy style)', async ({ request }) => {
 	// send request to create DID
 	let response = await request.post(`/did/create`, {
@@ -76,7 +84,7 @@ test('[Positive] It can create DID with mandatory and optional properties (Form 
 	expect(didDocument.verificationMethod[0].type).toBe(VerificationMethods.Ed255192018);
 	expect(didDocument.service[0].id).toBe(`${body.did}#service-1`);
 	expect(didDocument.service[0].type).toBe('LinkedDomains');
-	expect(didDocument.service[0].serviceEndpoint[0]).toBe('https://example.com');
+	expect(getServiceEndpointValue(didDocument.service[0].serviceEndpoint)).toBe('https://example.com');
 });
 
 test('[Positive] It can create  DID with mandatory properties (JSON based + Indy style)', async ({ request }) => {
@@ -174,5 +182,5 @@ test('[Positive] It can create DID with mandatory and optional properties (JSON 
 	expect(didDocument.verificationMethod[0].type).toBe(VerificationMethods.JWK);
 	expect(didDocument.service[0].id).toBe(`${did}#service-1`);
 	expect(didDocument.service[0].type).toBe('LinkedDomains');
-	expect(didDocument.service[0].serviceEndpoint[0]).toBe('https://example.com');
+	expect(getServiceEndpointValue(didDocument.service[0].serviceEndpoint)).toBe('https://example.com');
 });


### PR DESCRIPTION
- `PaymentEntity`: Changed resource property type from `ResourceEntity` to `ResourceEntity | null`
- `PaymentService`: Updated `create()` and `update() `method signatures to accept `ResourceEntity | null`
- `TrackOperationWithPayment`: Fixed `getResourceEntity()` to use proper type guards instead of hard-coded property checks
- `OperationSubscriber`: Removed error when no resource is found (since it's normal for some operations)

- Updated `release` test with `getServiceEndpointValue ` to comply with [this DID resolver fix](https://github.com/cheqd/did-resolver/commit/bc108be5f7c155e34d043bce227c44e9d93d6de2) 