### PR TITLE
feat: Include user scopes in idToken strategy

### DIFF
--- a/src/middleware/auth/user-info-fetcher/base.ts
+++ b/src/middleware/auth/user-info-fetcher/base.ts
@@ -23,10 +23,10 @@ export class UserInfoHelper {
 		return;
 	}
 
-    appendScopes(scopes: string[], response: Response) {
-        response.locals.scopes = Array.from(new Set([...response.locals.scopes, ...scopes]));
-        return;
-    }
+	appendScopes(scopes: string[], response: Response) {
+		response.locals.scopes = Array.from(new Set([...response.locals.scopes, ...scopes]));
+		return;
+	}
 
 	async setCustomerEntity(customerId: string, response: Response): Promise<Response | undefined> {
 		const customerEntity = await CustomerService.instance.get(customerId);

--- a/src/middleware/auth/user-info-fetcher/base.ts
+++ b/src/middleware/auth/user-info-fetcher/base.ts
@@ -22,6 +22,12 @@ export class UserInfoHelper {
 		response.locals.scopes = scopes;
 		return;
 	}
+
+    appendScopes(scopes: string[], response: Response) {
+        response.locals.scopes = Array.from(new Set([...response.locals.scopes, ...scopes]));
+        return;
+    }
+
 	async setCustomerEntity(customerId: string, response: Response): Promise<Response | undefined> {
 		const customerEntity = await CustomerService.instance.get(customerId);
 		if (!customerEntity) {

--- a/src/middleware/auth/user-info-fetcher/portal-token.ts
+++ b/src/middleware/auth/user-info-fetcher/portal-token.ts
@@ -53,8 +53,8 @@ export class PortalUserInfoFetcher extends UserInfoHelper implements IUserInfoFe
 					error: `Unauthorized error: No sub found in the token. Cannot set customerId.`,
 				} satisfies UnsuccessfulResponseBody);
 			}
-            // add user scopes
-            const _resp = await this.oauthProvider.getUserScopes(payload.sub);
+			// add user scopes
+			const _resp = await this.oauthProvider.getUserScopes(payload.sub);
 			if (_resp.status !== 200) {
 				return response.status(StatusCodes.UNAUTHORIZED).json({
 					error: `Unauthorized error: No scopes found for the user: ${payload.sub}`,

--- a/src/middleware/auth/user-info-fetcher/portal-token.ts
+++ b/src/middleware/auth/user-info-fetcher/portal-token.ts
@@ -53,6 +53,15 @@ export class PortalUserInfoFetcher extends UserInfoHelper implements IUserInfoFe
 					error: `Unauthorized error: No sub found in the token. Cannot set customerId.`,
 				} satisfies UnsuccessfulResponseBody);
 			}
+            // add user scopes
+            const _resp = await this.oauthProvider.getUserScopes(payload.sub);
+			if (_resp.status !== 200) {
+				return response.status(StatusCodes.UNAUTHORIZED).json({
+					error: `Unauthorized error: No scopes found for the user: ${payload.sub}`,
+				} satisfies UnsuccessfulResponseBody);
+			}
+			// Set global context
+			this.setScopes(_resp.data, response);
 			return await this.setUserEntity(payload.sub, response);
 		} catch (error) {
 			console.error(error);
@@ -79,7 +88,7 @@ export class PortalUserInfoFetcher extends UserInfoHelper implements IUserInfoFe
 				} satisfies UnsuccessfulResponseBody);
 			}
 			const scopes = payload.scope ? (payload.scope as string).split(' ') : [];
-			this.setScopes(scopes, response);
+			this.appendScopes(scopes, response);
 			return;
 		} catch (error) {
 			return response.status(StatusCodes.INTERNAL_SERVER_ERROR).json({


### PR DESCRIPTION
### Issue
The portal token strategy only considered scopes from the M2M token. Even if a user had the necessary permissions (scopes) assigned in Logto, these were not included in the effective scopes during API authorization.

### Fix
This PR updates the authentication strategy to:
   - Extract user-specific scopes from the ID Token payload.
   - Merge scopes from both the M2M token and the ID Token