### PR TITLE
feat: Align Basic/Build plans and add testnet faucet API

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,13 @@ some tokens on the testnet for making the process simpler.
 
 1. `ENABLE_ACCOUNT_TOPUP`: Enable/disable such functionality (`false` by default)
 2. `FAUCET_URI`: Faucet service API endpoint (Default: `https://faucet-api.cheqd.network/credit`)
-3. `TESTNET_MINIMUM_BALANCE`: Minimum balance on account before it is automatically topped up from the faucet. This value should be expressed as an integer in `CHEQ` tokens, which will then be converted in the background to `ncheq` denomination. Account balance check is carried out on every account creation/login. (Default: 10,000 CHEQ testnet tokens)
-4. `FAUCET_API_KEY`: API key for faucet service authentication
-5. `FAUCET_ACCESS_CLIENT_ID`: Cloudflare Access client ID for accessing the Testnet Faucet API
-6. `FAUCET_ACCESS_CLIENT_SECRET`: Cloudflare Access client secret for accessing the Testnet Faucet API
+3. `TESTNET_FAUCET_UPPER_CAP_CHEQ`: Upper cap for Studio-managed testnet faucet top-ups, expressed in `CHEQ` and converted to `ncheq` internally. This controls both automatic top-up and `POST /account/faucet`. (Default: `TESTNET_MINIMUM_BALANCE`, or 10,000 CHEQ)
+4. `TESTNET_MINIMUM_BALANCE`: Backward-compatible fallback for the faucet upper cap if `TESTNET_FAUCET_UPPER_CAP_CHEQ` is not set. (Default: 10,000 CHEQ testnet tokens)
+5. `FAUCET_API_KEY`: API key for faucet service authentication
+6. `FAUCET_ACCESS_CLIENT_ID`: Cloudflare Access client ID for accessing the Testnet Faucet API
+7. `FAUCET_ACCESS_CLIENT_SECRET`: Cloudflare Access client secret for accessing the Testnet Faucet API
+
+Studio exposes `POST /account/faucet` for authenticated Studio users on Basic-or-higher subscriptions. The endpoint accepts optional `address` and `amount` fields; `amount` is expressed in CHEQ. If `address` is omitted, Studio uses the customer's testnet payment account. If `amount` is omitted, Studio tops the address up to `TESTNET_FAUCET_UPPER_CAP_CHEQ`. Requests that exceed the remaining cap return a `requestMore.mailtoHref` for contacting `product@cheqd.io`.
 
 #### Stripe integration
 
@@ -120,8 +123,9 @@ The application supports Stripe integration for payment processing.
 2. `STRIPE_SECRET_KEY` - Secret key for Stripe API. Please, keep it secret on deploying
 3. `STRIPE_PUBLISHABLE_KEY` - Publishable key for Stripe API.
 4. `STRIPE_WEBHOOK_SECRET` - Secret for Stripe Webhook.
-5. `STRIPE_BUILD_PLAN_ID` - Subscription planId of Build plan
-6. `STRIPE_TEST_PLAN_ID` -  Subscription planId of Test plan
+5. `STRIPE_BUILD_PLAN_ID` - Subscription product ID of the Build plan
+6. `STRIPE_BASIC_PLAN_ID` - Subscription product ID of the Basic plan. This replaces the former Explorer/Test plan.
+7. `STRIPE_TEST_PLAN_ID` - Backward-compatible fallback product ID for the former Test/Explorer plan. Keep for one release while migrating to `STRIPE_BASIC_PLAN_ID`.
 
 ### 3rd Party Connectors
 

--- a/example.env
+++ b/example.env
@@ -36,13 +36,18 @@ HOVI_MASTER_API_KEY=hovi-master-account-key
 PROVIDER_EXPORT_PASSWORD=password-with-lowercase-uppercase-number-specialchar
 # Faucet settings
 ENABLE_ACCOUNT_TOPUP="false"
-TESTNET_MINIMUM_BALANCE="1000"
+TESTNET_MINIMUM_BALANCE="10000"
+TESTNET_FAUCET_UPPER_CAP_CHEQ="10000"
 # FAUCET_URI="https://faucet-api.cheqd.network/credit"
+# FAUCET_API_KEY="faucet-api-key"
+# FAUCET_ACCESS_CLIENT_ID="cloudflare-access-client-id"
+# FAUCET_ACCESS_CLIENT_SECRET="cloudflare-access-client-secret"
 
 STRIPE_ENABLED="false"
 STRIPE_WEBHOOK_SECRET="whs..ade"
 STRIPE_SECRET_KEY="sk_zzz..."
 STRIPE_BUILD_PLAN_ID="prod....5H"
+STRIPE_BASIC_PLAN_ID="prod....BA"
 STRIPE_TEST_PLAN_ID="prod....ST"
 
 # Verida

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@cheqd/studio",
-	"version": "3.16.1",
+	"version": "3.17.0-develop.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@cheqd/studio",
-			"version": "3.16.1",
+			"version": "3.17.0-develop.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@cheqd/did-provider-cheqd": "^4.8.0",
@@ -6073,8 +6073,8 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
 			"integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
-			"devOptional": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/@humanfs/core": {
 			"version": "0.19.1",
@@ -15265,8 +15265,8 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
 			"integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
-			"devOptional": true,
 			"license": "ISC",
+			"optional": true,
 			"dependencies": {
 				"@gar/promisify": "^1.0.1",
 				"semver": "^7.3.5"
@@ -15277,8 +15277,8 @@
 			"resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
 			"integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
 			"deprecated": "This functionality has been moved to @npmcli/fs",
-			"devOptional": true,
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"mkdirp": "^1.0.4",
 				"rimraf": "^3.0.2"
@@ -16869,8 +16869,8 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
 			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-			"devOptional": true,
 			"license": "MIT",
+			"optional": true,
 			"engines": {
 				"node": ">= 6"
 			}
@@ -24600,8 +24600,8 @@
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
 			"integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-			"devOptional": true,
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"humanize-ms": "^1.2.1"
 			},
@@ -25798,8 +25798,8 @@
 			"version": "15.3.0",
 			"resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
 			"integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
-			"devOptional": true,
 			"license": "ISC",
+			"optional": true,
 			"dependencies": {
 				"@npmcli/fs": "^1.0.0",
 				"@npmcli/move-file": "^1.0.1",
@@ -25828,8 +25828,8 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
 			"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-			"devOptional": true,
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"aggregate-error": "^3.0.0"
 			},
@@ -30288,8 +30288,8 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
 			"integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-			"devOptional": true,
-			"license": "BSD-2-Clause"
+			"license": "BSD-2-Clause",
+			"optional": true
 		},
 		"node_modules/http-errors": {
 			"version": "2.0.1",
@@ -30359,8 +30359,8 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
 			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-			"devOptional": true,
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"ms": "^2.0.0"
 			}
@@ -30539,8 +30539,8 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
 			"integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-			"devOptional": true,
-			"license": "ISC"
+			"license": "ISC",
+			"optional": true
 		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
@@ -30662,8 +30662,8 @@
 			"version": "10.1.0",
 			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
 			"integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-			"devOptional": true,
 			"license": "MIT",
+			"optional": true,
 			"engines": {
 				"node": ">= 12"
 			}
@@ -31196,8 +31196,8 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
 			"integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-			"devOptional": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
@@ -33777,8 +33777,8 @@
 			"version": "9.1.0",
 			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
 			"integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
-			"devOptional": true,
 			"license": "ISC",
+			"optional": true,
 			"dependencies": {
 				"agentkeepalive": "^4.1.3",
 				"cacache": "^15.2.0",
@@ -33805,8 +33805,8 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
 			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-			"devOptional": true,
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"debug": "4"
 			},
@@ -33818,8 +33818,8 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
 			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-			"devOptional": true,
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"@tootallnate/once": "1",
 				"agent-base": "6",
@@ -33833,8 +33833,8 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
 			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-			"devOptional": true,
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"agent-base": "6",
 				"debug": "4"
@@ -34620,8 +34620,8 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
 			"integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
-			"devOptional": true,
 			"license": "ISC",
+			"optional": true,
 			"dependencies": {
 				"minipass": "^3.0.0"
 			},
@@ -34633,8 +34633,8 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
 			"integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
-			"devOptional": true,
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"minipass": "^3.1.0",
 				"minipass-sized": "^1.0.3",
@@ -34651,8 +34651,8 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
 			"integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-			"devOptional": true,
 			"license": "ISC",
+			"optional": true,
 			"dependencies": {
 				"minipass": "^3.0.0"
 			},
@@ -34664,8 +34664,8 @@
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
 			"integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-			"devOptional": true,
 			"license": "ISC",
+			"optional": true,
 			"dependencies": {
 				"minipass": "^3.0.0"
 			},
@@ -34677,8 +34677,8 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
 			"integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-			"devOptional": true,
 			"license": "ISC",
+			"optional": true,
 			"dependencies": {
 				"minipass": "^3.0.0"
 			},
@@ -34872,8 +34872,8 @@
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
 			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-			"devOptional": true,
 			"license": "MIT",
+			"optional": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -35008,8 +35008,8 @@
 			"version": "8.4.1",
 			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
 			"integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
-			"devOptional": true,
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"env-paths": "^2.2.0",
 				"glob": "^7.1.4",
@@ -35045,8 +35045,8 @@
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
 			"integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
 			"deprecated": "This package is no longer supported.",
-			"devOptional": true,
 			"license": "ISC",
+			"optional": true,
 			"dependencies": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^3.6.0"
@@ -35060,8 +35060,8 @@
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
 			"integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
 			"deprecated": "This package is no longer supported.",
-			"devOptional": true,
 			"license": "ISC",
+			"optional": true,
 			"dependencies": {
 				"aproba": "^1.0.3 || ^2.0.0",
 				"color-support": "^1.1.3",
@@ -35081,8 +35081,8 @@
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
 			"integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
 			"deprecated": "This package is no longer supported.",
-			"devOptional": true,
 			"license": "ISC",
+			"optional": true,
 			"dependencies": {
 				"are-we-there-yet": "^3.0.0",
 				"console-control-strings": "^1.1.0",
@@ -35097,8 +35097,8 @@
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
 			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"devOptional": true,
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -35397,8 +35397,9 @@
 			"version": "11.0.3",
 			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.3.tgz",
 			"integrity": "sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==",
-			"devOptional": true,
 			"license": "ISC",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"hosted-git-info": "^7.0.0",
 				"proc-log": "^4.0.0",
@@ -38911,8 +38912,9 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
 			"integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
-			"devOptional": true,
 			"license": "ISC",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
@@ -38964,15 +38966,15 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
 			"integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
-			"devOptional": true,
-			"license": "ISC"
+			"license": "ISC",
+			"optional": true
 		},
 		"node_modules/promise-retry": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
 			"integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-			"devOptional": true,
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"err-code": "^2.0.2",
 				"retry": "^0.12.0"
@@ -38985,8 +38987,8 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
 			"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-			"devOptional": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/prompts": {
 			"version": "2.4.2",
@@ -39169,7 +39171,8 @@
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.11.0.tgz",
 			"integrity": "sha512-Uu7ii+FQy4Qf82G4xu7ShHhjhGahEpCWc3x8UavY3CTcWV+ufmmCtwkr7ZKsX42jdL0kr1B5FKUeqJvAn51jzQ==",
-			"devOptional": true,
+			"optional": true,
+			"peer": true,
 			"bin": {
 				"qrcode-terminal": "bin/qrcode-terminal.js"
 			}
@@ -40289,8 +40292,8 @@
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
 			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-			"devOptional": true,
 			"license": "MIT",
+			"optional": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -44242,8 +44245,8 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
 			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-			"devOptional": true,
 			"license": "MIT",
+			"optional": true,
 			"engines": {
 				"node": ">= 6.0.0",
 				"npm": ">= 3.0.0"
@@ -44253,8 +44256,8 @@
 			"version": "2.8.7",
 			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
 			"integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
-			"devOptional": true,
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"ip-address": "^10.0.1",
 				"smart-buffer": "^4.2.0"
@@ -44268,8 +44271,8 @@
 			"version": "6.2.1",
 			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
 			"integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
-			"devOptional": true,
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"agent-base": "^6.0.2",
 				"debug": "^4.3.3",
@@ -44283,8 +44286,8 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
 			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-			"devOptional": true,
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"debug": "4"
 			},
@@ -44474,8 +44477,8 @@
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
 			"integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
-			"devOptional": true,
 			"license": "ISC",
+			"optional": true,
 			"dependencies": {
 				"minipass": "^3.1.1"
 			},
@@ -46553,8 +46556,8 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
 			"integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
-			"devOptional": true,
 			"license": "ISC",
+			"optional": true,
 			"dependencies": {
 				"unique-slug": "^2.0.0"
 			}
@@ -46563,8 +46566,8 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
 			"integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
-			"devOptional": true,
 			"license": "ISC",
+			"optional": true,
 			"dependencies": {
 				"imurmurhash": "^0.1.4"
 			}
@@ -46900,8 +46903,9 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
 			"integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
-			"devOptional": true,
 			"license": "ISC",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}

--- a/scripts/MIGRATION-EXPLORER-PLAN.md
+++ b/scripts/MIGRATION-EXPLORER-PLAN.md
@@ -1,6 +1,6 @@
-# Explorer Plan Migration - Quick Reference
+# Basic Plan Migration - Quick Reference
 
-This guide provides step-by-step instructions for migrating all customers to the new Explorer plan.
+This guide provides step-by-step instructions for migrating all customers to the new Basic plan.
 
 ## Overview
 
@@ -17,8 +17,8 @@ The migration happens in **3 stages**:
 brew install jq  # or: apt-get install jq
 stripe login     # Authenticate Stripe CLI
 
-# 2. Get your Explorer plan price ID
-stripe prices list --product prod_EXPLORER_PLAN_ID
+# 2. Get your Basic plan price ID
+stripe prices list --product prod_BASIC_PLAN_ID
 # Copy the price ID (e.g., price_1QYqCEBuiFnKBR8qNnOoP123)
 
 # 3. Set up database access (if not already set)
@@ -70,7 +70,7 @@ Convert query results to JSON format and save to `scripts/subscriptions-to-activ
 
 ```bash
 cd /Users/sownakroy/project/studio
-./scripts/activate-subscriptions.sh price_YOUR_EXPLORER_PRICE_ID --status canceled --dry-run
+./scripts/activate-subscriptions.sh price_YOUR_BASIC_PRICE_ID --status canceled --dry-run
 ```
 
 **Review the output carefully:**
@@ -82,7 +82,7 @@ cd /Users/sownakroy/project/studio
 ### Step 1.4: Execute Migration
 
 ```bash
-./scripts/activate-subscriptions.sh price_YOUR_EXPLORER_PRICE_ID --status canceled
+./scripts/activate-subscriptions.sh price_YOUR_BASIC_PRICE_ID --status canceled
 ```
 
 Type `yes` when prompted to confirm.
@@ -135,13 +135,13 @@ Save results to `scripts/subscriptions-to-activate.json` (same file, overwrite).
 ### Step 2.3: Dry Run
 
 ```bash
-./scripts/activate-subscriptions.sh price_YOUR_EXPLORER_PRICE_ID --status trialing --dry-run
+./scripts/activate-subscriptions.sh price_YOUR_BASIC_PRICE_ID --status trialing --dry-run
 ```
 
 ### Step 2.4: Execute Migration
 
 ```bash
-./scripts/activate-subscriptions.sh price_YOUR_EXPLORER_PRICE_ID --status trialing
+./scripts/activate-subscriptions.sh price_YOUR_BASIC_PRICE_ID --status trialing
 ```
 
 Type `yes` when prompted.
@@ -195,13 +195,13 @@ Save results to `scripts/customers-without-subscriptions.json`:
 ### Step 3.3: Dry Run
 
 ```bash
-./scripts/create-stripe-subscriptions.sh price_YOUR_EXPLORER_PRICE_ID --dry-run
+./scripts/create-stripe-subscriptions.sh price_YOUR_BASIC_PRICE_ID --dry-run
 ```
 
 ### Step 3.4: Execute Creation
 
 ```bash
-./scripts/create-stripe-subscriptions.sh price_YOUR_EXPLORER_PRICE_ID
+./scripts/create-stripe-subscriptions.sh price_YOUR_BASIC_PRICE_ID
 ```
 
 Type `yes` when prompted.
@@ -274,20 +274,20 @@ Monitor Studio's webhook logs to ensure all subscription events were processed c
 
 - NEW subscription created (new subscription ID)
 - Old canceled subscription remains in history
-- Customer charged at Explorer plan price
+- Customer charged at Basic plan price
 
 **Trialing Subscriptions:**
 
 - SAME subscription ID (updated in place)
 - Trial ends immediately
-- Price changed to Explorer plan
+- Price changed to Basic plan
 - No prorations applied
 - Customer charged immediately
 
 **New Subscriptions:**
 
 - Brand new subscription created
-- Explorer plan price applied
+- Basic plan price applied
 - Customers charged based on billing cycle
 
 ### Communication

--- a/scripts/MIGRATION-EXPLORER-PLAN.md
+++ b/scripts/MIGRATION-EXPLORER-PLAN.md
@@ -279,10 +279,10 @@ Monitor Studio's webhook logs to ensure all subscription events were processed c
 **Trialing Subscriptions:**
 
 - SAME subscription ID (updated in place)
-- Trial ends immediately
 - Price changed to Basic plan
+- Existing trial end date is preserved
 - No prorations applied
-- Customer charged immediately
+- No immediate charge is created by the migration
 
 **New Subscriptions:**
 
@@ -304,8 +304,8 @@ Consider notifying customers before migration:
 Full rollback is difficult because:
 
 - Canceled subscriptions get new IDs
-- Trialing subscriptions have price changed and trial ended
-- Customers may have been charged
+- Trialing subscriptions have price changed in place
+- Customers with newly created paid subscriptions may have been charged
 
 **Always use dry-run first and test with small batches!**
 

--- a/scripts/README-SUBSCRIPTION-ACTIVATION.md
+++ b/scripts/README-SUBSCRIPTION-ACTIVATION.md
@@ -541,7 +541,7 @@ stripe subscriptions cancel sub_newxyz789
 
 **Note:** Full rollback is difficult because:
 
-- Trialing subscriptions had their price changed and trial ended
+- Trialing subscriptions had their price changed in place while preserving the trial end date
 - Canceled subscriptions got NEW subscription IDs
 - Always test with dry-run and small batches first!
 

--- a/scripts/README-SUBSCRIPTION-ACTIVATION.md
+++ b/scripts/README-SUBSCRIPTION-ACTIVATION.md
@@ -3,12 +3,12 @@
 This guide helps you migrate and activate subscriptions by:
 
 - Moving existing subscriptions to a new Stripe price/plan
-- Activating trialing subscriptions (ending trial immediately)
+- Updating active/trialing subscriptions without prorations
 - Reactivating canceled subscriptions (creating new subscriptions)
 
 ## What This Does
 
-- **Trialing subscriptions**: Migrates to new price AND ends trial immediately, making them active
+- **Active/trialing subscriptions**: Migrates to new price with `proration_behavior=none`
 - **Canceled subscriptions**: Creates NEW subscription with new price (cannot update canceled subscriptions)
 
 ## Prerequisites
@@ -25,7 +25,7 @@ This guide helps you migrate and activate subscriptions by:
 # Copy results from database and save to: scripts/subscriptions-to-activate.json
 
 # 2. Get your target Stripe price ID
-stripe prices list --product prod_EXPLORER_PLAN_ID
+stripe prices list --product prod_BASIC_PLAN_ID
 
 # 3. Dry run to see what would happen
 ./scripts/activate-subscriptions.sh price_1234567890 --dry-run
@@ -35,12 +35,13 @@ stripe prices list --product prod_EXPLORER_PLAN_ID
 
 # 5. Or activate only specific status
 ./scripts/activate-subscriptions.sh price_1234567890 --status trialing
+./scripts/activate-subscriptions.sh price_1234567890 --status active
 ./scripts/activate-subscriptions.sh price_1234567890 --status canceled
 ```
 
-## 2-Stage Migration to Explorer Plan
+## 2-Stage Migration to Basic Plan
 
-When migrating all customers to a new plan (e.g., "Explorer" plan), use this 2-stage approach:
+When migrating all customers to a new plan (e.g., "Basic" plan), use this 2-stage approach:
 
 ### Why 2 Stages?
 
@@ -58,20 +59,20 @@ When migrating all customers to a new plan (e.g., "Explorer" plan), use this 2-s
 # Step 2: Save results manually to JSON
 # Copy query results and save to: scripts/subscriptions-to-activate.json
 
-# Step 3: Get your Explorer plan price ID
-stripe prices list --product prod_EXPLORER_PLAN_ID
+# Step 3: Get your Basic plan price ID
+stripe prices list --product prod_BASIC_PLAN_ID
 
 # Step 4: Dry run first
-./scripts/activate-subscriptions.sh price_EXPLORER_PLAN_ID --status canceled --dry-run
+./scripts/activate-subscriptions.sh price_BASIC_PRICE_ID --status canceled --dry-run
 
 # Step 5: Execute migration
-./scripts/activate-subscriptions.sh price_EXPLORER_PLAN_ID --status canceled
+./scripts/activate-subscriptions.sh price_BASIC_PRICE_ID --status canceled
 ```
 
 **What happens:**
 
 - Creates NEW subscriptions for canceled customers
-- Uses Explorer plan price ID
+- Uses Basic plan price ID
 - Old canceled subscriptions remain canceled (new subscription IDs created)
 
 ### Stage 2: Migrate Trialing/Active Subscriptions
@@ -85,10 +86,10 @@ stripe prices list --product prod_EXPLORER_PLAN_ID
 # Copy query results and save to: scripts/subscriptions-to-activate.json
 
 # Step 3: Dry run first
-./scripts/activate-subscriptions.sh price_EXPLORER_PLAN_ID --status trialing --dry-run
+./scripts/activate-subscriptions.sh price_BASIC_PRICE_ID --status trialing --dry-run
 
 # Step 4: Execute migration
-./scripts/activate-subscriptions.sh price_EXPLORER_PLAN_ID --status trialing
+./scripts/activate-subscriptions.sh price_BASIC_PRICE_ID --status trialing
 ```
 
 **What happens:**
@@ -108,16 +109,16 @@ stripe prices list --product prod_EXPLORER_PLAN_ID
 # Copy query results and save to: scripts/customers-without-subscriptions.json
 
 # Step 3: Dry run first
-./scripts/create-stripe-subscriptions.sh price_EXPLORER_PLAN_ID --dry-run
+./scripts/create-stripe-subscriptions.sh price_BASIC_PRICE_ID --dry-run
 
 # Step 4: Execute creation
-./scripts/create-stripe-subscriptions.sh price_EXPLORER_PLAN_ID
+./scripts/create-stripe-subscriptions.sh price_BASIC_PRICE_ID
 ```
 
 **What happens:**
 
 - Creates brand new subscriptions for customers with no subscription history
-- Uses Explorer plan price ID
+- Uses Basic plan price ID
 
 ## Detailed Steps
 
@@ -165,7 +166,7 @@ Find the price ID for your target plan:
 
 ```bash
 # List prices for a product
-stripe prices list --product prod_EXPLORER_PLAN_ID
+stripe prices list --product prod_BASIC_PLAN_ID
 
 # Or retrieve a specific price
 stripe prices retrieve price_1234567890
@@ -231,8 +232,7 @@ You'll be asked to confirm before proceeding. The script will:
 1. Retrieve subscription to get all item IDs
 2. Delete all existing subscription items
 3. Add new subscription item with target price
-4. End trial immediately (`trial_end=now`)
-5. Set `proration_behavior=none` (no prorations)
+4. Set `proration_behavior=none` (no prorations)
 
 **After:**
 
@@ -334,8 +334,7 @@ Processing: user1@example.com (Status: trialing)
     1. Retrieve subscription to get all item IDs
     2. Delete all existing subscription items
     3. Add new subscription item with price: price_1QYqCEBuiFnKBR8qNnOoP123
-    4. End trial: trial_end=now
-    5. Set proration_behavior=none (no prorations)
+    4. Set proration_behavior=none (no prorations)
 
 Processing: user2@example.com (Status: canceled)
   Stripe Subscription ID: sub_def456
@@ -371,7 +370,8 @@ canceled: 58
 This will update 156 subscriptions in Stripe
 Actions:
   - Migrate all subscriptions to price: price_1QYqCEBuiFnKBR8qNnOoP123
-  - Trialing: End trial immediately (make active)
+  - Active: Update price with proration_behavior=none
+  - Trialing: Update price with proration_behavior=none
   - Canceled: Reactivate subscription
 
 Are you sure you want to continue? (yes/no): yes
@@ -386,7 +386,7 @@ Processing: user1@example.com (Status: trialing)
   Current Status: trialing
   Step 1/3: Retrieving subscription details...
   Found 1 subscription item(s)
-  Step 2/3: Updating subscription to new price and ending trial...
+  Step 2/3: Updating subscription to new price...
   Step 3/3: Executing update...
   ✓ Successfully migrated subscription to price_1QYqCEBuiFnKBR8qNnOoP123
 
@@ -480,15 +480,15 @@ Log file: scripts/subscription-activation-20250122-154530.log
 
 ```bash
 # Stage 1: Migrate canceled subscriptions first
-./scripts/activate-subscriptions.sh price_EXPLORER_PLAN_ID --status canceled
+./scripts/activate-subscriptions.sh price_BASIC_PRICE_ID --status canceled
 
 # Wait and monitor for issues in Stripe dashboard and logs
 
 # Stage 2: Migrate trialing subscriptions
-./scripts/activate-subscriptions.sh price_EXPLORER_PLAN_ID --status trialing
+./scripts/activate-subscriptions.sh price_BASIC_PRICE_ID --status trialing
 
 # Stage 3: Handle customers without any subscriptions
-./scripts/create-stripe-subscriptions.sh price_EXPLORER_PLAN_ID
+./scripts/create-stripe-subscriptions.sh price_BASIC_PRICE_ID
 ```
 
 ### Verify Changes in Stripe
@@ -570,7 +570,7 @@ stripe subscriptions cancel sub_newxyz789
 
 ## Complete Migration Workflow
 
-### For Explorer Plan Migration (Full Process)
+### For Basic Plan Migration (Full Process)
 
 ```bash
 # ============================================
@@ -581,14 +581,14 @@ stripe subscriptions cancel sub_newxyz789
 # Run in DB: SELECT * FROM find-subscriptions-to-activate.sql WHERE status='canceled'
 # Save to: scripts/subscriptions-to-activate.json
 
-# 2. Get Explorer price ID
-stripe prices list --product prod_EXPLORER_PLAN_ID
+# 2. Get Basic price ID
+stripe prices list --product prod_BASIC_PLAN_ID
 
 # 3. Dry run
-./scripts/activate-subscriptions.sh price_EXPLORER_ID --status canceled --dry-run
+./scripts/activate-subscriptions.sh price_BASIC_ID --status canceled --dry-run
 
 # 4. Execute
-./scripts/activate-subscriptions.sh price_EXPLORER_ID --status canceled
+./scripts/activate-subscriptions.sh price_BASIC_ID --status canceled
 
 # 5. Monitor and verify
 # - Check Stripe dashboard
@@ -604,10 +604,10 @@ stripe prices list --product prod_EXPLORER_PLAN_ID
 # Save to: scripts/subscriptions-to-activate.json
 
 # 2. Dry run
-./scripts/activate-subscriptions.sh price_EXPLORER_ID --status trialing --dry-run
+./scripts/activate-subscriptions.sh price_BASIC_ID --status trialing --dry-run
 
 # 3. Execute
-./scripts/activate-subscriptions.sh price_EXPLORER_ID --status trialing
+./scripts/activate-subscriptions.sh price_BASIC_ID --status trialing
 
 # 4. Monitor and verify
 
@@ -620,10 +620,10 @@ stripe prices list --product prod_EXPLORER_PLAN_ID
 # Save to: scripts/customers-without-subscriptions.json
 
 # 2. Dry run
-./scripts/create-stripe-subscriptions.sh price_EXPLORER_ID --dry-run
+./scripts/create-stripe-subscriptions.sh price_BASIC_ID --dry-run
 
 # 3. Execute
-./scripts/create-stripe-subscriptions.sh price_EXPLORER_ID
+./scripts/create-stripe-subscriptions.sh price_BASIC_ID
 
 # 4. Monitor and verify
 

--- a/scripts/README-SUBSCRIPTION-MIGRATION.md
+++ b/scripts/README-SUBSCRIPTION-MIGRATION.md
@@ -134,7 +134,7 @@ cat scripts/subscription-creation-YYYYMMDD-HHMMSS.log
 
 1. **README-SUBSCRIPTION-MIGRATION.md** - This file (for creating NEW subscriptions)
 1. **README-SUBSCRIPTION-ACTIVATION.md** - Guide for migrating/activating EXISTING subscriptions
-1. **MIGRATION-EXPLORER-PLAN.md** - Quick reference for Explorer plan migration
+1. **MIGRATION-EXPLORER-PLAN.md** - Quick reference for Basic plan migration
 
 ## Troubleshooting
 
@@ -199,8 +199,8 @@ Add custom metadata to subscriptions:
 # 1. Authenticate with Stripe
 stripe login
 
-# 2. Get your Explorer plan price ID
-stripe prices list --product prod_EXPLORER_PLAN_ID
+# 2. Get your Basic plan price ID
+stripe prices list --product prod_BASIC_PLAN_ID
 
 # 3. Run SQL query in your database
 # Run: scripts/find-customers-without-subscriptions.sql
@@ -231,7 +231,7 @@ stripe subscriptions list --status active --limit 20
 ## Related Guides
 
 - **README-SUBSCRIPTION-ACTIVATION.md** - For migrating/activating EXISTING subscriptions (trialing/canceled)
-- **MIGRATION-EXPLORER-PLAN.md** - Quick reference for complete Explorer plan migration (all 3 stages)
+- **MIGRATION-EXPLORER-PLAN.md** - Quick reference for complete Basic plan migration (all 3 stages)
 
 ## Support
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,7 +8,7 @@ This folder contains scripts and documentation for managing Stripe subscription 
 
 | File | Purpose | When to Use |
 |------|---------|-------------|
-| **MIGRATION-EXPLORER-PLAN.md** | Quick reference for Explorer plan migration | Start here for complete migration walkthrough |
+| **MIGRATION-EXPLORER-PLAN.md** | Quick reference for Basic plan migration | Start here for complete migration walkthrough |
 | **README-SUBSCRIPTION-ACTIVATION.md** | Detailed guide for migrating/activating existing subscriptions | When you have trialing or canceled subscriptions to migrate |
 | **README-SUBSCRIPTION-MIGRATION.md** | Guide for creating new subscriptions | When customers have NO subscription at all |
 | **README.md** | This file - overview of all scripts | Navigation and understanding the system |
@@ -45,7 +45,7 @@ This folder contains scripts and documentation for managing Stripe subscription 
 
 **What it does:**
 
-- **Trialing subscriptions:** Updates to new price, ends trial immediately, keeps same subscription ID
+- **Active/trialing subscriptions:** Updates to new price without prorations, keeps same subscription ID
 - **Canceled subscriptions:** Creates NEW subscription with new price (new subscription ID)
 
 **Example:**
@@ -81,27 +81,27 @@ This folder contains scripts and documentation for managing Stripe subscription 
 
 ---
 
-## Complete Explorer Plan Migration
+## Complete Basic Plan Migration
 
-For a complete migration to the Explorer plan, follow this 3-stage process:
+For a complete migration to the Basic plan, follow this 3-stage process:
 
 ### Stage 1: Migrate Canceled Subscriptions
 
 1. Run `find-subscriptions-to-activate.sql` with `WHERE status='canceled'`
 2. Save results to `scripts/subscriptions-to-activate.json`
-3. Run: `./scripts/activate-subscriptions.sh price_EXPLORER --status canceled`
+3. Run: `./scripts/activate-subscriptions.sh price_BASIC --status canceled`
 
 ### Stage 2: Migrate Trialing Subscriptions
 
 1. Run `find-subscriptions-to-activate.sql` with `WHERE status='trialing'`
 2. Save results to `scripts/subscriptions-to-activate.json`
-3. Run: `./scripts/activate-subscriptions.sh price_EXPLORER --status trialing`
+3. Run: `./scripts/activate-subscriptions.sh price_BASIC --status trialing`
 
 ### Stage 3: Create Subscriptions for New Customers
 
 1. Run `find-customers-without-subscriptions.sql`
 2. Save results to `scripts/customers-without-subscriptions.json`
-3. Run: `./scripts/create-stripe-subscriptions.sh price_EXPLORER`
+3. Run: `./scripts/create-stripe-subscriptions.sh price_BASIC`
 
 **See MIGRATION-EXPLORER-PLAN.md for detailed step-by-step instructions.**
 
@@ -250,7 +250,7 @@ Before running any migration:
 4. **Price ID** - Get your target plan's price ID
 
    ```bash
-   stripe prices list --product prod_EXPLORER_PLAN_ID
+   stripe prices list --product prod_BASIC_PLAN_ID
    ```
 
 ---
@@ -378,8 +378,8 @@ These logs contain:
 ## Quick Start Commands
 
 ```bash
-# Get Explorer plan price ID
-stripe prices list --product prod_EXPLORER_PLAN_ID
+# Get Basic plan price ID
+stripe prices list --product prod_BASIC_PLAN_ID
 
 # Stage 1: Migrate canceled subscriptions
 ./scripts/activate-subscriptions.sh price_XXX --status canceled --dry-run

--- a/scripts/activate-subscriptions.sh
+++ b/scripts/activate-subscriptions.sh
@@ -9,7 +9,7 @@
 # Arguments:
 #   price_id: The Stripe price ID to migrate subscriptions to (e.g., price_xxx)
 #   --dry-run: Optional flag to preview actions without updating subscriptions
-#   --status: Optional filter for specific status (trialing|canceled). Default: both
+#   --status: Optional filter for specific status (active|trialing|canceled). Default: all
 #
 # Requirements:
 #   - Stripe CLI installed (https://stripe.com/docs/stripe-cli)
@@ -19,6 +19,7 @@
 #
 # Examples:
 #   ./scripts/activate-subscriptions.sh price_1234567890 --dry-run
+#   ./scripts/activate-subscriptions.sh price_1234567890 --status active
 #   ./scripts/activate-subscriptions.sh price_1234567890 --status trialing
 #   ./scripts/activate-subscriptions.sh price_1234567890 --status canceled --dry-run
 #   ./scripts/activate-subscriptions.sh price_1234567890
@@ -125,7 +126,8 @@ if [ "$DRY_RUN" = false ]; then
   echo -e "${YELLOW}This will update $TOTAL_SUBS subscriptions in Stripe${NC}"
   echo -e "${YELLOW}Actions:${NC}"
   echo -e "  - Migrate all subscriptions to price: $PRICE_ID"
-  echo -e "  - Trialing: End trial immediately (make active)"
+  echo -e "  - Active: Update price with proration_behavior=none"
+  echo -e "  - Trialing: Update price with proration_behavior=none"
   echo -e "  - Canceled: Reactivate subscription"
   echo ""
   read -p "Are you sure you want to continue? (yes/no): " -r
@@ -162,12 +164,11 @@ while read -r subscription; do
 
   if [ "$DRY_RUN" = true ]; then
     echo -e "${YELLOW}  [DRY RUN] Would execute:${NC}"
-    if [ "$STATUS" == "trialing" ]; then
+    if [ "$STATUS" == "active" ] || [ "$STATUS" == "trialing" ]; then
       echo "    1. Retrieve subscription to get all item IDs"
       echo "    2. Delete all existing subscription items"
       echo "    3. Add new subscription item with price: $PRICE_ID"
-      echo "    4. End trial: trial_end=now"
-      echo "    5. Set proration_behavior=none (no prorations)"
+      echo "    4. Set proration_behavior=none (no prorations)"
     elif [ "$STATUS" == "canceled" ]; then
       echo "    1. Create NEW subscription for customer: $STRIPE_CUSTOMER_ID"
       echo "    2. Use price: $PRICE_ID"
@@ -204,8 +205,8 @@ while read -r subscription; do
       ((ERROR_COUNT++))
     fi
 
-  elif [ "$STATUS" == "trialing" ]; then
-    # For trialing subscriptions, update and end trial
+  elif [ "$STATUS" == "active" ] || [ "$STATUS" == "trialing" ]; then
+    # For active/trialing subscriptions, update the subscription price without prorations.
     echo "  Step 1/3: Retrieving subscription details..."
     if ! SUB_DATA=$(stripe subscriptions retrieve "$STRIPE_SUB_ID" 2>&1); then
       echo -e "${RED}  ✗ Failed to retrieve subscription${NC}"
@@ -228,7 +229,7 @@ while read -r subscription; do
     fi
 
     echo "  Found ${#ITEM_IDS[@]} subscription item(s)"
-    echo "  Step 2/3: Updating subscription to new price and ending trial..."
+    echo "  Step 2/3: Updating subscription to new price..."
 
     # Build the command to update subscription
     STRIPE_CMD="stripe subscriptions update $STRIPE_SUB_ID"
@@ -243,12 +244,11 @@ while read -r subscription; do
     NEXT_INDEX=${#ITEM_IDS[@]}
     STRIPE_CMD="$STRIPE_CMD -d \"items[$NEXT_INDEX][price]=$PRICE_ID\""
     STRIPE_CMD="$STRIPE_CMD -d proration_behavior=none"
-    STRIPE_CMD="$STRIPE_CMD -d trial_end=now"
 
     echo "  Step 3/3: Executing update..."
     if RESULT=$(eval "$STRIPE_CMD" 2>&1); then
       echo -e "${GREEN}  ✓ Successfully migrated subscription to $PRICE_ID${NC}"
-      echo "SUCCESS: $EMAIL ($STRIPE_SUB_ID) - Migrated from trialing to active with price $PRICE_ID" >> "$LOG_FILE"
+      echo "SUCCESS: $EMAIL ($STRIPE_SUB_ID) - Migrated $STATUS subscription to price $PRICE_ID with no proration" >> "$LOG_FILE"
       ((SUCCESS_COUNT++))
     else
       echo -e "${RED}  ✗ Failed to update subscription${NC}"

--- a/scripts/find-subscriptions-to-activate.sql
+++ b/scripts/find-subscriptions-to-activate.sql
@@ -1,4 +1,4 @@
--- Find subscriptions with status 'trialing' or 'canceled' that need to be activated
+-- Find subscriptions with status 'active', 'trialing', or 'canceled' that need to be migrated
 SELECT
     s."subscriptionId",
     s."customerId",
@@ -11,7 +11,7 @@ SELECT
     c."name"
 FROM "subscription" s
 INNER JOIN "customer" c ON s."customerId" = c."customerId"
-WHERE s."status" IN ('trialing', 'canceled')
+WHERE s."status" IN ('active', 'trialing', 'canceled')
 ORDER BY s."status", c."email";
 
 -- Summary counts by status
@@ -19,5 +19,5 @@ ORDER BY s."status", c."email";
 --     s."status",
 --     COUNT(*) as count
 -- FROM "subscription" s
--- WHERE s."status" IN ('trialing', 'canceled')
+-- WHERE s."status" IN ('active', 'trialing', 'canceled')
 -- GROUP BY s."status";

--- a/src/app.ts
+++ b/src/app.ts
@@ -307,6 +307,7 @@ class App {
 
 		// Account API
 		app.post('/account/create', AccountController.createValidator, new AccountController().create);
+		app.post('/account/faucet', AccountController.faucetValidator, new AccountController().requestFaucetTokens);
 		app.get('/account', new AccountController().get);
 		app.get('/account/idtoken', new AccountController().getIdToken);
 		app.get('/account/analytics', new AccountController().getAnalytics);

--- a/src/controllers/api/account.ts
+++ b/src/controllers/api/account.ts
@@ -13,7 +13,12 @@ import type Stripe from 'stripe';
 import type { SafeAPIResponse } from '../../types/common.js';
 
 import { CheqdNetwork, checkBalance } from '@cheqd/sdk';
-import { TESTNET_MINIMUM_BALANCE, DEFAULT_DENOM_EXPONENT, OperationNameEnum } from '../../types/constants.js';
+import {
+	DEFAULT_DENOM_EXPONENT,
+	MINIMAL_DENOM,
+	OperationNameEnum,
+	TESTNET_FAUCET_UPPER_CAP_CHEQ,
+} from '../../types/constants.js';
 import { CustomerService } from '../../services/api/customer.js';
 import { LogToHelper } from '../../middleware/auth/logto-helper.js';
 import { FaucetHelper } from '../../helpers/faucet.js';
@@ -40,6 +45,7 @@ import { Credentials } from '../../services/api/credentials.js';
 import { ResourceService } from '../../services/api/resource.js';
 import { CredentialCategory } from '../../types/credential.js';
 import { Like } from 'typeorm';
+import { productHasCapability, StudioPlanCapability } from '../../services/admin/plan-capabilities.js';
 
 dotenv.config();
 
@@ -53,6 +59,11 @@ export class AccountController {
 			.withMessage('Invalid email id')
 			.bail(),
 		check('name').optional().isString().withMessage('name should be a valid string'),
+	];
+
+	public static faucetValidator = [
+		check('address').optional().isString().notEmpty().withMessage('address should be a valid string').bail(),
+		check('amount').optional().isFloat({ gt: 0 }).withMessage('amount should be a positive number').bail(),
 	];
 	/**
 	 * @openapi
@@ -542,7 +553,9 @@ export class AccountController {
 			if (testnetAccount.address && process.env.ENABLE_ACCOUNT_TOPUP === 'true') {
 				const balances = await checkBalance(testnetAccount.address, process.env.TESTNET_RPC_URL);
 				const balance = balances[0];
-				if (!balance || +balance.amount < TESTNET_MINIMUM_BALANCE * Math.pow(10, DEFAULT_DENOM_EXPONENT)) {
+				const topupAmountNcheq =
+					cheqToNcheq(TESTNET_FAUCET_UPPER_CAP_CHEQ) - BigInt(balance?.amount || '0');
+				if (topupAmountNcheq > 0n) {
 					// 3.1 If it's less then required for DID creation - assign new portion from testnet-faucet
 					// Handle case where firstName or lastName is not set
 					const faucetFirstName = logToFirstName || customerEntity.name;
@@ -551,7 +564,8 @@ export class AccountController {
 						testnetAccount.address,
 						faucetFirstName,
 						faucetLastName,
-						customerEntity.email
+						customerEntity.email,
+						Number(topupAmountNcheq)
 					);
 
 					if (resp.status !== StatusCodes.OK) {
@@ -577,6 +591,163 @@ export class AccountController {
 			return response.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
 				error: `Internal Error: ${(error as Error)?.message || error}`,
 			});
+		}
+	}
+
+	/**
+	 * @openapi
+	 *
+	 * /account/faucet:
+	 *   post:
+	 *     tags: [Account]
+	 *     summary: Request cheqd testnet CHEQ tokens for a Studio payment account.
+	 *     description: Funds an authenticated Studio user's owned testnet payment account up to the configured faucet cap.
+	 *     requestBody:
+	 *       content:
+	 *         application/json:
+	 *           schema:
+	 *             type: object
+	 *             properties:
+	 *               address:
+	 *                 type: string
+	 *                 description: Optional owned Studio testnet payment account address. Defaults to the authenticated customer's testnet account.
+	 *               amount:
+	 *                 type: number
+	 *                 description: Optional amount in CHEQ. Defaults to the amount needed to top up to the configured cap.
+	 *     responses:
+	 *       200:
+	 *         description: The request was processed.
+	 *       400:
+	 *         $ref: '#/components/schemas/InvalidRequest'
+	 *       401:
+	 *         $ref: '#/components/schemas/UnauthorizedError'
+	 *       403:
+	 *         description: Forbidden.
+	 *       500:
+	 *         $ref: '#/components/schemas/InternalError'
+	 */
+	@validate
+	public async requestFaucetTokens(request: Request, response: Response) {
+		if (request.headers['x-api-key'] || request.headers['customer-id']) {
+			return response.status(StatusCodes.FORBIDDEN).json({
+				error: 'Faucet requests are only available to authenticated Studio users.',
+			} satisfies UnsuccessfulResponseBody);
+		}
+
+		if (!response.locals.user || !response.locals.customer) {
+			return response.status(StatusCodes.UNAUTHORIZED).json({
+				error: 'Unauthorized error: Studio user context was not found.',
+			} satisfies UnsuccessfulResponseBody);
+		}
+
+		if (process.env.STRIPE_ENABLED !== 'true') {
+			return response.status(StatusCodes.SERVICE_UNAVAILABLE).json({
+				error: 'Faucet requests require Stripe subscription checks to be enabled.',
+			} satisfies UnsuccessfulResponseBody);
+		}
+
+		const customer = response.locals.customer as CustomerEntity;
+		const stripe = response.locals.stripe as Stripe;
+		const requestedAddress = request.body.address as string | undefined;
+		const requestedAmountCheq =
+			request.body.amount !== undefined ? Number(request.body.amount) : undefined;
+
+		try {
+			const subscription = await SubscriptionService.instance.findCurrent(customer);
+			if (!subscription) {
+				return response.status(StatusCodes.FORBIDDEN).json({
+					error: 'An active Basic or higher subscription is required to request testnet CHEQ tokens.',
+				} satisfies UnsuccessfulResponseBody);
+			}
+
+			const stripeSubscription = await stripe.subscriptions.retrieve(subscription.subscriptionId);
+			if (!['active', 'trialing'].includes(stripeSubscription.status)) {
+				return response.status(StatusCodes.FORBIDDEN).json({
+					error: 'An active Basic or higher subscription is required to request testnet CHEQ tokens.',
+				} satisfies UnsuccessfulResponseBody);
+			}
+
+			const productId = getStripeObjectKey(stripeSubscription.items.data[0].plan.product);
+			if (!productHasCapability(productId, StudioPlanCapability.Faucet)) {
+				return response.status(StatusCodes.FORBIDDEN).json({
+					error: 'The current subscription does not include testnet faucet access.',
+				} satisfies UnsuccessfulResponseBody);
+			}
+
+			const testnetAccount = await resolveFaucetAccount(customer, requestedAddress);
+			if (!testnetAccount) {
+				return response.status(requestedAddress ? StatusCodes.FORBIDDEN : StatusCodes.NOT_FOUND).json({
+					error: requestedAddress
+						? 'The requested address is not an owned Studio testnet payment account.'
+						: 'No Studio testnet payment account was found for this customer.',
+				} satisfies UnsuccessfulResponseBody);
+			}
+
+			const capNcheq = cheqToNcheq(TESTNET_FAUCET_UPPER_CAP_CHEQ);
+			if (capNcheq <= 0n) {
+				return response.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+					error: 'Invalid TESTNET_FAUCET_UPPER_CAP_CHEQ configuration.',
+				} satisfies UnsuccessfulResponseBody);
+			}
+
+			const currentBalanceNcheq = await getTestnetBalanceNcheq(testnetAccount.address);
+			const maxAllowedNcheq = capNcheq - currentBalanceNcheq;
+			const balance = buildFaucetBalanceResponse(currentBalanceNcheq, capNcheq, maxAllowedNcheq);
+
+			if (maxAllowedNcheq <= 0n) {
+				return response.status(StatusCodes.OK).json({
+					funded: false,
+					reason: 'cap_reached',
+					address: testnetAccount.address,
+					balance,
+					requestMore: buildRequestMore(customer, testnetAccount.address, balance, requestedAmountCheq),
+				});
+			}
+
+			const amountToRequestNcheq =
+				requestedAmountCheq === undefined ? maxAllowedNcheq : cheqToNcheq(requestedAmountCheq);
+
+			if (amountToRequestNcheq <= 0n) {
+				return response.status(StatusCodes.BAD_REQUEST).json({
+					error: 'amount is too small to request.',
+				} satisfies UnsuccessfulResponseBody);
+			}
+
+			if (amountToRequestNcheq > maxAllowedNcheq) {
+				return response.status(StatusCodes.BAD_REQUEST).json({
+					error: 'Requested amount exceeds the maximum available top-up for this address.',
+					address: testnetAccount.address,
+					balance,
+					requestMore: buildRequestMore(customer, testnetAccount.address, balance, requestedAmountCheq),
+				});
+			}
+
+			const faucet = await FaucetHelper.delegateTokens(
+				testnetAccount.address,
+				customer.name,
+				'n/a',
+				customer.email,
+				Number(amountToRequestNcheq)
+			);
+			if (faucet.status !== StatusCodes.OK) {
+				return response.status(StatusCodes.BAD_GATEWAY).json({
+					error: 'Faucet request failed.',
+				} satisfies UnsuccessfulResponseBody);
+			}
+
+			return response.status(StatusCodes.OK).json({
+				funded: true,
+				address: testnetAccount.address,
+				amount: {
+					cheq: ncheqToCheq(amountToRequestNcheq),
+					ncheq: amountToRequestNcheq.toString(),
+				},
+				balance,
+			});
+		} catch (error) {
+			return response.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+				error: `Internal error: ${(error as Error)?.message || error}`,
+			} satisfies UnsuccessfulResponseBody);
 		}
 	}
 
@@ -654,6 +825,92 @@ export class AccountController {
 	}
 }
 
+const FAUCET_REQUEST_MORE_EMAIL = 'product@cheqd.io';
+const FAUCET_REQUEST_MORE_SUBJECT = 'Request more cheqd testnet CHEQ tokens';
+
+function cheqToNcheq(amountCheq: number): bigint {
+	return BigInt(Math.floor(amountCheq * 10 ** DEFAULT_DENOM_EXPONENT));
+}
+
+function ncheqToCheq(amountNcheq: bigint): number {
+	return Number(amountNcheq) / 10 ** DEFAULT_DENOM_EXPONENT;
+}
+
+function buildFaucetBalanceResponse(currentBalanceNcheq: bigint, capNcheq: bigint, maxAllowedNcheq: bigint) {
+	const remainingNcheq = maxAllowedNcheq > 0n ? maxAllowedNcheq : 0n;
+	return {
+		denom: MINIMAL_DENOM,
+		current: {
+			cheq: ncheqToCheq(currentBalanceNcheq),
+			ncheq: currentBalanceNcheq.toString(),
+		},
+		cap: {
+			cheq: ncheqToCheq(capNcheq),
+			ncheq: capNcheq.toString(),
+		},
+		maxRequestable: {
+			cheq: ncheqToCheq(remainingNcheq),
+			ncheq: remainingNcheq.toString(),
+		},
+	};
+}
+
+async function getTestnetBalanceNcheq(address: string): Promise<bigint> {
+	const balances = await checkBalance(address, process.env.TESTNET_RPC_URL);
+	const balance = balances.find((coin) => coin.denom === MINIMAL_DENOM) || balances[0];
+	return BigInt(balance?.amount || '0');
+}
+
+async function resolveFaucetAccount(
+	customer: CustomerEntity,
+	requestedAddress?: string
+): Promise<PaymentAccountEntity | null> {
+	if (requestedAddress) {
+		return PaymentAccountService.instance.findOne({
+			address: requestedAddress,
+			namespace: CheqdNetwork.Testnet,
+			customer,
+		});
+	}
+
+	return PaymentAccountService.instance.findOne({
+		namespace: CheqdNetwork.Testnet,
+		customer,
+	});
+}
+
+function buildRequestMore(
+	customer: CustomerEntity,
+	address: string,
+	balance: ReturnType<typeof buildFaucetBalanceResponse>,
+	requestedAmountCheq?: number
+) {
+	const requestedAmount = requestedAmountCheq === undefined ? 'Not provided' : `${requestedAmountCheq} CHEQ`;
+	const body = [
+		'Hello cheqd Product team,',
+		'',
+		'I would like to request more cheqd testnet CHEQ tokens.',
+		'',
+		`Full name: ${customer.name}`,
+		`Email: ${customer.email}`,
+		`Requesting address: ${address}`,
+		`Current balance: ${balance.current.cheq} CHEQ`,
+		`Configured cap: ${balance.cap.cheq} CHEQ`,
+		`Requested amount: ${requestedAmount}`,
+		'',
+		'Reason:',
+		'[Please add your reason here]',
+	].join('\n');
+
+	return {
+		email: FAUCET_REQUEST_MORE_EMAIL,
+		subject: FAUCET_REQUEST_MORE_SUBJECT,
+		mailtoHref: `mailto:${FAUCET_REQUEST_MORE_EMAIL}?subject=${encodeURIComponent(
+			FAUCET_REQUEST_MORE_SUBJECT
+		)}&body=${encodeURIComponent(body)}`,
+	};
+}
+
 async function syncLogtoUserRoles(
 	logToHelper: LogToHelper,
 	stripe: Stripe,
@@ -679,7 +936,7 @@ async function syncLogtoUserRoles(
 		);
 
 		const roleResponse = await logToHelper.assignCustomerPlanRoles(logToUserId, stripeProduct);
-		if (roleResponse.status !== StatusCodes.OK) {
+		if (roleResponse.status !== StatusCodes.OK && roleResponse.status !== StatusCodes.CREATED) {
 			return {
 				success: false,
 				status: roleResponse.status,
@@ -748,7 +1005,8 @@ async function topupTestnet(
 	try {
 		const balances = await checkBalance(testnetResp.data.address, process.env.TESTNET_RPC_URL);
 		const bal = balances[0];
-		if (!bal || +bal.amount < TESTNET_MINIMUM_BALANCE * 10 ** DEFAULT_DENOM_EXPONENT) {
+		const topupAmountNcheq = cheqToNcheq(TESTNET_FAUCET_UPPER_CAP_CHEQ) - BigInt(bal?.amount || '0');
+		if (topupAmountNcheq > 0n) {
 			// Handle case where firstName or lastName is not set
 			const faucetFirstName = firstName || customer.name;
 			const faucetLastName = lastName || 'n/a';
@@ -756,7 +1014,8 @@ async function topupTestnet(
 				testnetResp.data.address,
 				faucetFirstName,
 				faucetLastName,
-				customer.email
+				customer.email,
+				Number(topupAmountNcheq)
 			);
 			if (faucet.status === StatusCodes.OK) {
 				status.testnetMinimumBalance = true;

--- a/src/controllers/api/account.ts
+++ b/src/controllers/api/account.ts
@@ -551,10 +551,8 @@ export class AccountController {
 
 			// 4. Check the token balance for Testnet account
 			if (testnetAccount.address && process.env.ENABLE_ACCOUNT_TOPUP === 'true') {
-				const balances = await checkBalance(testnetAccount.address, process.env.TESTNET_RPC_URL);
-				const balance = balances[0];
 				const topupAmountNcheq =
-					cheqToNcheq(TESTNET_FAUCET_UPPER_CAP_CHEQ) - BigInt(balance?.amount || '0');
+					cheqToNcheq(TESTNET_FAUCET_UPPER_CAP_CHEQ) - (await getTestnetBalanceNcheq(testnetAccount.address));
 				if (topupAmountNcheq > 0n) {
 					// 3.1 If it's less then required for DID creation - assign new portion from testnet-faucet
 					// Handle case where firstName or lastName is not set
@@ -565,7 +563,7 @@ export class AccountController {
 						faucetFirstName,
 						faucetLastName,
 						customerEntity.email,
-						Number(topupAmountNcheq)
+						toSafeFaucetAmount(topupAmountNcheq)
 					);
 
 					if (resp.status !== StatusCodes.OK) {
@@ -623,6 +621,12 @@ export class AccountController {
 	 *         $ref: '#/components/schemas/UnauthorizedError'
 	 *       403:
 	 *         description: Forbidden.
+	 *       404:
+	 *         description: No Studio testnet payment account was found for this customer.
+	 *       502:
+	 *         description: Upstream faucet request failed.
+	 *       503:
+	 *         description: Stripe subscription checks are disabled.
 	 *       500:
 	 *         $ref: '#/components/schemas/InternalError'
 	 */
@@ -649,8 +653,7 @@ export class AccountController {
 		const customer = response.locals.customer as CustomerEntity;
 		const stripe = response.locals.stripe as Stripe;
 		const requestedAddress = request.body.address as string | undefined;
-		const requestedAmountCheq =
-			request.body.amount !== undefined ? Number(request.body.amount) : undefined;
+		const requestedAmountCheq = request.body.amount !== undefined ? Number(request.body.amount) : undefined;
 
 		try {
 			const subscription = await SubscriptionService.instance.findCurrent(customer);
@@ -727,7 +730,7 @@ export class AccountController {
 				customer.name,
 				'n/a',
 				customer.email,
-				Number(amountToRequestNcheq)
+				toSafeFaucetAmount(amountToRequestNcheq)
 			);
 			if (faucet.status !== StatusCodes.OK) {
 				return response.status(StatusCodes.BAD_GATEWAY).json({
@@ -836,6 +839,14 @@ function ncheqToCheq(amountNcheq: bigint): number {
 	return Number(amountNcheq) / 10 ** DEFAULT_DENOM_EXPONENT;
 }
 
+function toSafeFaucetAmount(amountNcheq: bigint): number {
+	if (amountNcheq > BigInt(Number.MAX_SAFE_INTEGER)) {
+		throw new Error('Faucet amount exceeds JavaScript safe integer range.');
+	}
+
+	return Number(amountNcheq);
+}
+
 function buildFaucetBalanceResponse(currentBalanceNcheq: bigint, capNcheq: bigint, maxAllowedNcheq: bigint) {
 	const remainingNcheq = maxAllowedNcheq > 0n ? maxAllowedNcheq : 0n;
 	return {
@@ -857,7 +868,7 @@ function buildFaucetBalanceResponse(currentBalanceNcheq: bigint, capNcheq: bigin
 
 async function getTestnetBalanceNcheq(address: string): Promise<bigint> {
 	const balances = await checkBalance(address, process.env.TESTNET_RPC_URL);
-	const balance = balances.find((coin) => coin.denom === MINIMAL_DENOM) || balances[0];
+	const balance = balances.find((coin) => coin.denom === MINIMAL_DENOM);
 	return BigInt(balance?.amount || '0');
 }
 
@@ -1003,9 +1014,8 @@ async function topupTestnet(
 		return;
 	}
 	try {
-		const balances = await checkBalance(testnetResp.data.address, process.env.TESTNET_RPC_URL);
-		const bal = balances[0];
-		const topupAmountNcheq = cheqToNcheq(TESTNET_FAUCET_UPPER_CAP_CHEQ) - BigInt(bal?.amount || '0');
+		const topupAmountNcheq =
+			cheqToNcheq(TESTNET_FAUCET_UPPER_CAP_CHEQ) - (await getTestnetBalanceNcheq(testnetResp.data.address));
 		if (topupAmountNcheq > 0n) {
 			// Handle case where firstName or lastName is not set
 			const faucetFirstName = firstName || customer.name;
@@ -1015,7 +1025,7 @@ async function topupTestnet(
 				faucetFirstName,
 				faucetLastName,
 				customer.email,
-				Number(topupAmountNcheq)
+				toSafeFaucetAmount(topupAmountNcheq)
 			);
 			if (faucet.status === StatusCodes.OK) {
 				status.testnetMinimumBalance = true;

--- a/src/helpers/faucet.ts
+++ b/src/helpers/faucet.ts
@@ -1,11 +1,11 @@
 import type { ICommonErrorResponse } from '../types/authentication.js';
-import { 
-	MINIMAL_DENOM, 
-	FAUCET_URI, 
-	FAUCET_AMOUNT, 
-	FAUCET_API_KEY, 
-	FAUCET_ACCESS_CLIENT_ID, 
-	FAUCET_ACCESS_CLIENT_SECRET 
+import {
+	MINIMAL_DENOM,
+	FAUCET_URI,
+	FAUCET_AMOUNT,
+	FAUCET_API_KEY,
+	FAUCET_ACCESS_CLIENT_ID,
+	FAUCET_ACCESS_CLIENT_SECRET,
 } from '../types/constants.js';
 
 export class FaucetHelper {
@@ -14,7 +14,8 @@ export class FaucetHelper {
 		address: string,
 		firstName: string,
 		lastName: string,
-		email: string
+		email: string,
+		amount = FAUCET_AMOUNT
 	): Promise<ICommonErrorResponse> {
 		const faucetURI = FAUCET_URI;
 		const faucetBody = {
@@ -24,7 +25,7 @@ export class FaucetHelper {
 			first_name: firstName,
 			last_name: lastName,
 			company: 'Requested via cheqd Studio',
-			amount: FAUCET_AMOUNT,
+			amount,
 			marketing_optin: false,
 		};
 		const response = await fetch(faucetURI, {

--- a/src/middleware/auth/logto-helper.ts
+++ b/src/middleware/auth/logto-helper.ts
@@ -7,6 +7,7 @@ import { OAuthProvider } from './oauth/abstract.js';
 import { EventTracker, eventTracker } from '../../services/track/tracker.js';
 import { env } from 'node:process';
 import Stripe from 'stripe';
+import { productHasCapability, StudioPlanCapability } from '../../services/admin/plan-capabilities.js';
 
 dotenv.config();
 
@@ -280,17 +281,17 @@ export class LogToHelper extends OAuthProvider implements IOAuthProvider {
 		const assignedRoleIds = (userRoles.data as { id: string; name: string }[]).map((role) => role.id);
 
 		// INFO: Context
-		// We currently have two plans, Build and Test.
+		// We currently have two paid plan families: Build and Basic.
 		// All of our users get a "Portal" role which let's them work with our Studio Portal (UI)
-		// Test plan lets you operate with our Testnet so we assign the "Testnet" role
-		// Build plan lets you work with our Testnet and Mainnet, so we assign "Testnet" and "Mainnet" roles
+		// Basic lets you operate with our Testnet so we assign the "Testnet" role.
+		// Build lets you work with our Testnet and Mainnet, so we assign "Testnet" and "Mainnet" roles.
 		// "build" is the superset of all the roles (testnet + mainnet)
 		const buildPlanRoleIds = [env.LOGTO_MAINNET_ROLE_ID.trim(), env.LOGTO_TESTNET_ROLE_ID.trim()];
 		const testPlanRoleId = env.LOGTO_TESTNET_ROLE_ID.trim();
 		const hasDefaultPortalRole = assignedRoleIds.findIndex((roleId) => roleId === env.LOGTO_DEFAULT_ROLE_ID) != -1;
 
 		const planRoleIds = hasDefaultPortalRole ? [] : [env.LOGTO_DEFAULT_ROLE_ID.trim()];
-		if (product.id === process.env.STRIPE_BUILD_PLAN_ID) {
+		if (productHasCapability(product.id, StudioPlanCapability.Mainnet)) {
 			const buildRoleIsAssigned = buildPlanRoleIds.every((roleId) => assignedRoleIds.includes(roleId));
 			if (buildRoleIsAssigned) {
 				return {
@@ -304,7 +305,7 @@ export class LogToHelper extends OAuthProvider implements IOAuthProvider {
 
 			const billingPlanRoleIds = buildPlanRoleIds.filter((id) => !assignedRoleIds.includes(id));
 			planRoleIds.push(...billingPlanRoleIds);
-		} else if (product.id === process.env.STRIPE_TEST_PLAN_ID) {
+		} else if (productHasCapability(product.id, StudioPlanCapability.Testnet)) {
 			// "build" plan is a superset of "test" plan
 
 			// check the user has mainnet role, remove it

--- a/src/middleware/auth/logto-helper.ts
+++ b/src/middleware/auth/logto-helper.ts
@@ -282,7 +282,7 @@ export class LogToHelper extends OAuthProvider implements IOAuthProvider {
 
 		// INFO: Context
 		// We currently have two paid plan families: Build and Basic.
-		// All of our users get a "Portal" role which let's them work with our Studio Portal (UI)
+		// All of our users get a "Portal" role which lets them work with our Studio Portal (UI)
 		// Basic lets you operate with our Testnet so we assign the "Testnet" role.
 		// Build lets you work with our Testnet and Mainnet, so we assign "Testnet" and "Mainnet" roles.
 		// "build" is the superset of all the roles (testnet + mainnet)

--- a/src/middleware/auth/routes/api/account-auth.ts
+++ b/src/middleware/auth/routes/api/account-auth.ts
@@ -4,6 +4,7 @@ export class AccountAuthProvider extends AuthRuleProvider {
 	constructor() {
 		super();
 		this.registerRule('/account', 'GET', 'read:account', { skipNamespace: true });
+		this.registerRule('/account/faucet', 'POST', 'request:faucet:testnet', { skipNamespace: true });
 		this.registerRule('/account', 'POST', 'create:account', { skipNamespace: true });
 		this.registerRule('/account/idtoken', 'GET', 'read:account', { skipNamespace: true });
 		this.registerRule('/account/analytics', 'GET', 'read:account', { skipNamespace: true });

--- a/src/services/admin/plan-capabilities.ts
+++ b/src/services/admin/plan-capabilities.ts
@@ -4,8 +4,14 @@ export enum StudioPlanCapability {
 	Faucet = 'faucet',
 }
 
+export function getBasicPlanIds(): string[] {
+	return Array.from(
+		new Set([process.env.STRIPE_BASIC_PLAN_ID, process.env.STRIPE_TEST_PLAN_ID].filter((id): id is string => !!id))
+	);
+}
+
 export function getBasicPlanId(): string {
-	return process.env.STRIPE_BASIC_PLAN_ID || process.env.STRIPE_TEST_PLAN_ID || '';
+	return getBasicPlanIds()[0] || '';
 }
 
 export function getBuildPlanId(): string {
@@ -13,8 +19,7 @@ export function getBuildPlanId(): string {
 }
 
 export function isBasicPlan(productId: string): boolean {
-	const basicPlanId = getBasicPlanId();
-	return Boolean(basicPlanId && productId === basicPlanId);
+	return getBasicPlanIds().includes(productId);
 }
 
 export function isBuildPlan(productId: string): boolean {

--- a/src/services/admin/plan-capabilities.ts
+++ b/src/services/admin/plan-capabilities.ts
@@ -1,0 +1,35 @@
+export enum StudioPlanCapability {
+	Testnet = 'testnet',
+	Mainnet = 'mainnet',
+	Faucet = 'faucet',
+}
+
+export function getBasicPlanId(): string {
+	return process.env.STRIPE_BASIC_PLAN_ID || process.env.STRIPE_TEST_PLAN_ID || '';
+}
+
+export function getBuildPlanId(): string {
+	return process.env.STRIPE_BUILD_PLAN_ID || '';
+}
+
+export function isBasicPlan(productId: string): boolean {
+	const basicPlanId = getBasicPlanId();
+	return Boolean(basicPlanId && productId === basicPlanId);
+}
+
+export function isBuildPlan(productId: string): boolean {
+	const buildPlanId = getBuildPlanId();
+	return Boolean(buildPlanId && productId === buildPlanId);
+}
+
+export function productHasCapability(productId: string, capability: StudioPlanCapability): boolean {
+	if (isBuildPlan(productId)) {
+		return true;
+	}
+
+	if (!isBasicPlan(productId)) {
+		return false;
+	}
+
+	return capability === StudioPlanCapability.Testnet || capability === StudioPlanCapability.Faucet;
+}

--- a/src/services/track/admin/account-submitter.ts
+++ b/src/services/track/admin/account-submitter.ts
@@ -106,11 +106,16 @@ export class PortalAccountCreateSubmitter implements IObserver {
 	}
 
 	async assignDefaultPlan(stripe: Stripe, paymentProviderId: string) {
+		const basicPlanId = getBasicPlanId();
+		if (!basicPlanId) {
+			throw new Error('STRIPE_BASIC_PLAN_ID or STRIPE_TEST_PLAN_ID must be configured to assign default plan');
+		}
+
 		// Get the product to find its default price
-		const product = await stripe.products.retrieve(getBasicPlanId());
+		const product = await stripe.products.retrieve(basicPlanId);
 
 		if (!product.default_price) {
-			throw new Error(`Product ${getBasicPlanId()} has no default price set`);
+			throw new Error(`Product ${basicPlanId} has no default price set`);
 		}
 
 		// Get the price ID (could be string or Price object)

--- a/src/services/track/admin/account-submitter.ts
+++ b/src/services/track/admin/account-submitter.ts
@@ -6,6 +6,7 @@ import { EventTracker } from '../tracker.js';
 import { StatusCodes } from 'http-status-codes';
 import { CustomerService } from '../../api/customer.js';
 import type { ISubmitOperation, ISubmitStripeCustomerCreateData } from '../submitter.js';
+import { getBasicPlanId } from '../../admin/plan-capabilities.js';
 
 export class PortalAccountCreateSubmitter implements IObserver {
 	private emitter: EventEmitter;
@@ -66,8 +67,8 @@ export class PortalAccountCreateSubmitter implements IObserver {
 					paymentProviderId: stripeCustomer.id,
 				});
 
-				// Replace trial plan with default plan (with the STRIPE_TEST_PLAN_ID env var set)
-				if (process.env.STRIPE_TEST_PLAN_ID) {
+				// Assign Basic as the default paid plan, keeping STRIPE_TEST_PLAN_ID as a one-release fallback.
+				if (getBasicPlanId()) {
 					// Assign default plan to the user
 					await this.assignDefaultPlan(stripe, stripeCustomer.id);
 				}
@@ -106,10 +107,10 @@ export class PortalAccountCreateSubmitter implements IObserver {
 
 	async assignDefaultPlan(stripe: Stripe, paymentProviderId: string) {
 		// Get the product to find its default price
-		const product = await stripe.products.retrieve(process.env.STRIPE_TEST_PLAN_ID as string);
+		const product = await stripe.products.retrieve(getBasicPlanId());
 
 		if (!product.default_price) {
-			throw new Error(`Product ${process.env.STRIPE_TEST_PLAN_ID} has no default price set`);
+			throw new Error(`Product ${getBasicPlanId()} has no default price set`);
 		}
 
 		// Get the price ID (could be string or Price object)

--- a/src/static/swagger-api.json
+++ b/src/static/swagger-api.json
@@ -3361,6 +3361,60 @@
         }
       }
     },
+    "/account/faucet": {
+      "post": {
+        "tags": [
+          "Account"
+        ],
+        "summary": "Request cheqd testnet CHEQ tokens for a Studio payment account.",
+        "description": "Funds an authenticated Studio user's owned testnet payment account up to the configured faucet cap.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "address": {
+                    "type": "string",
+                    "description": "Optional owned Studio testnet payment account address. Defaults to the authenticated customer's testnet account."
+                  },
+                  "amount": {
+                    "type": "number",
+                    "description": "Optional amount in CHEQ. Defaults to the amount needed to top up to the configured cap."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The request was processed."
+          },
+          "400": {
+            "$ref": "#/components/schemas/InvalidRequest"
+          },
+          "401": {
+            "$ref": "#/components/schemas/UnauthorizedError"
+          },
+          "403": {
+            "description": "Forbidden."
+          },
+          "404": {
+            "description": "No Studio testnet payment account was found for this customer."
+          },
+          "500": {
+            "$ref": "#/components/schemas/InternalError"
+          },
+          "502": {
+            "description": "Upstream faucet request failed."
+          },
+          "503": {
+            "description": "Stripe subscription checks are disabled."
+          }
+        }
+      }
+    },
     "/account/analytics": {
       "get": {
         "tags": [

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -51,12 +51,22 @@ export const configLogToExpress = {
 };
 
 // Faucet constants
+const parseNumberEnv = (value: string | undefined, fallback: number): number => {
+	if (!value?.trim()) return fallback;
+	const parsed = Number(value);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
 export const MINIMAL_DENOM = 'ncheq';
 export const FAUCET_URI = process.env.FAUCET_URI || 'https://faucet-api.cheqd.network/credit';
 export const FAUCET_API_KEY = process.env.FAUCET_API_KEY || 'default-api-key';
 export const DEFAULT_DENOM_EXPONENT = 9;
-export const TESTNET_MINIMUM_BALANCE = process.env.TESTNET_MINIMUM_BALANCE || 1000;
-export const FAUCET_AMOUNT = process.env.FAUCET_AMOUNT || 100000000000000;
+export const TESTNET_MINIMUM_BALANCE = parseNumberEnv(process.env.TESTNET_MINIMUM_BALANCE, 10000);
+export const TESTNET_FAUCET_UPPER_CAP_CHEQ = parseNumberEnv(
+	process.env.TESTNET_FAUCET_UPPER_CAP_CHEQ,
+	TESTNET_MINIMUM_BALANCE
+);
+export const FAUCET_AMOUNT = parseNumberEnv(process.env.FAUCET_AMOUNT, 100000000000000);
 export const FAUCET_ACCESS_CLIENT_ID = process.env.FAUCET_ACCESS_CLIENT_ID || '';
 export const FAUCET_ACCESS_CLIENT_SECRET = process.env.FAUCET_ACCESS_CLIENT_SECRET || '';
 

--- a/src/types/environment.d.ts
+++ b/src/types/environment.d.ts
@@ -55,7 +55,12 @@ declare global {
 			// Faucet
 			ENABLE_ACCOUNT_TOPUP: string | 'false';
 			FAUCET_URI: string;
-			TESTNET_MINIMUM_BALANCE: number;
+			FAUCET_API_KEY: string;
+			FAUCET_AMOUNT: string;
+			FAUCET_ACCESS_CLIENT_ID: string;
+			FAUCET_ACCESS_CLIENT_SECRET: string;
+			TESTNET_MINIMUM_BALANCE: string;
+			TESTNET_FAUCET_UPPER_CAP_CHEQ: string;
 
 			// Creds
 			CREDS_DECRYPTION_SECRET: string;
@@ -70,6 +75,7 @@ declare global {
 			STRIPE_PUBLISHABLE_KEY: string;
 			STRIPE_WEBHOOK_SECRET: string;
 			STRIPE_BUILD_PLAN_ID: string;
+			STRIPE_BASIC_PLAN_ID: string | undefined;
 			STRIPE_TEST_PLAN_ID: string;
 
 			// Mailchimp

--- a/tests/unit/admin/plan-capabilities.test.ts
+++ b/tests/unit/admin/plan-capabilities.test.ts
@@ -40,6 +40,12 @@ describe('plan capabilities', () => {
 		expect(productHasCapability('prod_basic', StudioPlanCapability.Mainnet)).toBe(false);
 	});
 
+	it('allows legacy Test plan testnet and faucet capabilities during migration', () => {
+		expect(productHasCapability('prod_test', StudioPlanCapability.Testnet)).toBe(true);
+		expect(productHasCapability('prod_test', StudioPlanCapability.Faucet)).toBe(true);
+		expect(productHasCapability('prod_test', StudioPlanCapability.Mainnet)).toBe(false);
+	});
+
 	it('allows Build all capabilities', () => {
 		expect(productHasCapability('prod_build', StudioPlanCapability.Testnet)).toBe(true);
 		expect(productHasCapability('prod_build', StudioPlanCapability.Faucet)).toBe(true);

--- a/tests/unit/admin/plan-capabilities.test.ts
+++ b/tests/unit/admin/plan-capabilities.test.ts
@@ -1,0 +1,48 @@
+import {
+	getBasicPlanId,
+	productHasCapability,
+	StudioPlanCapability,
+} from '../../../src/services/admin/plan-capabilities.js';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+
+describe('plan capabilities', () => {
+	const originalStripeEnv = {
+		STRIPE_BASIC_PLAN_ID: process.env.STRIPE_BASIC_PLAN_ID,
+		STRIPE_BUILD_PLAN_ID: process.env.STRIPE_BUILD_PLAN_ID,
+		STRIPE_TEST_PLAN_ID: process.env.STRIPE_TEST_PLAN_ID,
+	};
+
+	beforeEach(() => {
+		process.env.STRIPE_BASIC_PLAN_ID = 'prod_basic';
+		process.env.STRIPE_BUILD_PLAN_ID = 'prod_build';
+		process.env.STRIPE_TEST_PLAN_ID = 'prod_test';
+	});
+
+	afterEach(() => {
+		process.env.STRIPE_BASIC_PLAN_ID = originalStripeEnv.STRIPE_BASIC_PLAN_ID;
+		process.env.STRIPE_BUILD_PLAN_ID = originalStripeEnv.STRIPE_BUILD_PLAN_ID;
+		process.env.STRIPE_TEST_PLAN_ID = originalStripeEnv.STRIPE_TEST_PLAN_ID;
+	});
+
+	it('uses STRIPE_BASIC_PLAN_ID before the legacy test plan fallback', () => {
+		expect(getBasicPlanId()).toBe('prod_basic');
+	});
+
+	it('falls back to STRIPE_TEST_PLAN_ID when basic is not configured', () => {
+		delete process.env.STRIPE_BASIC_PLAN_ID;
+
+		expect(getBasicPlanId()).toBe('prod_test');
+	});
+
+	it('allows Basic testnet and faucet capabilities only', () => {
+		expect(productHasCapability('prod_basic', StudioPlanCapability.Testnet)).toBe(true);
+		expect(productHasCapability('prod_basic', StudioPlanCapability.Faucet)).toBe(true);
+		expect(productHasCapability('prod_basic', StudioPlanCapability.Mainnet)).toBe(false);
+	});
+
+	it('allows Build all capabilities', () => {
+		expect(productHasCapability('prod_build', StudioPlanCapability.Testnet)).toBe(true);
+		expect(productHasCapability('prod_build', StudioPlanCapability.Faucet)).toBe(true);
+		expect(productHasCapability('prod_build', StudioPlanCapability.Mainnet)).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary
- add Basic/Build plan capability mapping and keep the legacy test plan only as a fallback
- add authenticated `POST /account/faucet` access for Studio users with cap, balance, and request-more response details
- update subscription activation/migration docs and env examples for Basic/Build plan IDs
- add focused unit coverage for plan capabilities

## Verification
- `npm run build:app`
- `npm run test:unit -- tests/unit/admin/plan-capabilities.test.ts --runInBand`

## Notes
- No Stripe migration or price-shift scripts were run.
- Runtime env should set `STRIPE_BASIC_PLAN_ID` and `STRIPE_BUILD_PLAN_ID`; `STRIPE_TEST_PLAN_ID` remains a temporary fallback only.