### PR TITLE
feat: Start Basic plan as trial for new Studio accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ The application supports Stripe integration for payment processing.
 6. `STRIPE_BASIC_PLAN_ID` - Subscription product ID of the Basic plan. This replaces the former Explorer/Test plan.
 7. `STRIPE_TEST_PLAN_ID` - Backward-compatible fallback product ID for the former Test/Explorer plan. Keep for one release while migrating to `STRIPE_BASIC_PLAN_ID`.
 
+When a new Studio customer is created with Stripe enabled, Studio creates a Stripe customer and starts the Basic plan as a 30-day trial subscription. This makes the customer immediately `trialing` for subscription checks without requiring a payment method at signup.
+
 ### 3rd Party Connectors
 
 The app supports 3rd party connectors for credential storage and delivery.

--- a/src/services/track/admin/account-submitter.ts
+++ b/src/services/track/admin/account-submitter.ts
@@ -1,6 +1,6 @@
 import Stripe from 'stripe';
 import type { IObserver } from '../types.js';
-import { OperationNameEnum } from '../../../types/constants.js';
+import { MaxAllowedTrialPeriodDays, OperationNameEnum } from '../../../types/constants.js';
 import type { INotifyMessage } from '../../../types/track.js';
 import { EventTracker } from '../tracker.js';
 import { StatusCodes } from 'http-status-codes';
@@ -67,7 +67,7 @@ export class PortalAccountCreateSubmitter implements IObserver {
 					paymentProviderId: stripeCustomer.id,
 				});
 
-				// Assign Basic as the default paid plan, keeping STRIPE_TEST_PLAN_ID as a one-release fallback.
+				// Assign Basic as the default trialing plan, keeping STRIPE_TEST_PLAN_ID as a one-release fallback.
 				if (getBasicPlanId()) {
 					// Assign default plan to the user
 					await this.assignDefaultPlan(stripe, stripeCustomer.id);
@@ -128,10 +128,16 @@ export class PortalAccountCreateSubmitter implements IObserver {
 			payment_settings: {
 				save_default_payment_method: 'on_subscription',
 			},
+			trial_period_days: MaxAllowedTrialPeriodDays,
+			trial_settings: {
+				end_behavior: {
+					missing_payment_method: 'cancel',
+				},
+			},
 		});
 
 		if (subscriptionResponse.lastResponse.statusCode !== StatusCodes.OK) {
-			throw new Error(`Failed to assign default plan`);
+			throw new Error(`Failed to assign default Basic trial plan`);
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- start the default Basic subscription as a 30-day trial when a new Stripe customer is created
- preserve cancel-on-missing-payment-method behavior at trial end
- document that new Studio customers become `trialing` immediately after signup when Stripe is enabled

## Verification
- `npm run build:app`
- `npm run test:unit -- tests/unit/admin/plan-capabilities.test.ts --runInBand`

## Notes
- This is a follow-up to #811 after it was merged. It prevents new signups from ending up with an `incomplete` paid subscription and no current subscription in Studio.